### PR TITLE
Small fix of file size information

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,8 +33,8 @@ def reporthook(count, block_size, total_size):
 	progress_size = int(count * block_size)
 	speed = int(progress_size / (1024 * duration))
 	percent = min(int(count*block_size*100/total_size),100)
-	sys.stdout.write("\r...%d%%, %d MB, %d KB/s, %d seconds passed" %
-					(percent, progress_size / (1024 * 1024), speed, duration))
+	sys.stdout.write("\r...%d%%, %d KB, %d KB/s, %d seconds passed" %
+					(percent, progress_size / 1024, speed, duration))
 	sys.stdout.flush()
 
 def getsecondrow(filename):


### PR DESCRIPTION
Print the file size in kilobytes instead of megabytes (because it's smaller than 1 MB).